### PR TITLE
fixed bottle github link

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -16,7 +16,7 @@ export class ConfigurationTester implements vscode.Disposable {
       if (error) {
         if ((<any>error).code === 'ENOENT') {
           vscode.window.showErrorMessage(
-              'Please install [Bottle](http://https://github.com/vntchain/bottle/) or check configuration `bottle.executable`');
+              'Please install [Bottle](https://github.com/vntchain/bottle/) or check configuration `bottle.executable`');
         }
         // else {
         //   vscode.window.showErrorMessage(


### PR DESCRIPTION
Fixed a bug that the bottle's github link had an extra http in configuration.ts

![38731d91640e7879a052d35b0a412a5](https://user-images.githubusercontent.com/22947379/62905238-eb3a4580-bdac-11e9-9211-330aa5691600.png)

The link in the vs code notification was broken
